### PR TITLE
EOL and redirect to org.gnome.gitlab.somas.Apostrophe

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+    "end-of-life": "Application has been renamed to org.gnome.gitlab.somas.Apostrophe",
+    "end-of-life-rebase": "org.gnome.gitlab.somas.Apostrophe",
+    "skip-appstream-check": true
+}


### PR DESCRIPTION
We need to push flathub.json EOL and redirects to this app, the beta branch and then the same for the textlive extension before we can archive the repo.